### PR TITLE
Unicode and error strings

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -8,9 +8,6 @@
         "Pgn",
         "Pgn.Extra"
     ],
-    "source-directories": [
-        "src"
-    ],
     "elm-version": "0.19.1 <= v < 0.20.0",
     "dependencies": {
         "elm/core": "1.0.5 <= v < 2.0.0",
@@ -18,6 +15,10 @@
         "elm-community/list-extra": "8.2.4 <= v < 9.0.0"
     },
     "test-dependencies": {
-        "elm-explorations/test": "1.2.2 <= v < 2.0.0"
-    }
+        "elm-explorations/test": "1.2.2 <= v < 2.0.0",
+        "elm-community/random-extra": "3.1.0 <= v < 4.0.0"
+    },
+    "source-directories": [
+        "src"
+    ]
 }

--- a/src/Pgn.elm
+++ b/src/Pgn.elm
@@ -209,36 +209,41 @@ parseErrorToString source deadEnds =
                 let
                     row =
                         rows |> List.Extra.getAt (de.row - 1) |> Maybe.withDefault ""
+
+                    update a _ =
+                        ( a ++ " ", [] )
+
+                    {- start with spaces to cover the lenght of the row's leading characters "> " -}
+                    inital =
+                        "  "
+
+                    --
+                    ( spacesToProblem, _ ) =
+                        List.Extra.mapAccuml update inital <| List.range 1 de.row
                 in
-                "error on row:  "
+                "\n\nerror on row:  "
                     ++ String.fromInt de.row
                     ++ ", col: "
                     ++ String.fromInt de.col
                     ++ ". Problem: "
                     ++ problemToString de.problem
-                    ++ "\n\n"
-                    ++ "> '"
+                    ++ "\n"
+                    ++ "> "
                     ++ row
-                    ++ "'\n"
-                    ++ (row |> String.toList |> List.Extra.getAt (de.col - 6) |> Maybe.map String.fromChar |> Maybe.withDefault "")
-                    ++ (row |> String.toList |> List.Extra.getAt (de.col - 5) |> Maybe.map String.fromChar |> Maybe.withDefault "")
-                    ++ (row |> String.toList |> List.Extra.getAt (de.col - 4) |> Maybe.map String.fromChar |> Maybe.withDefault "")
-                    ++ (row |> String.toList |> List.Extra.getAt (de.col - 3) |> Maybe.map String.fromChar |> Maybe.withDefault "")
-                    ++ (row |> String.toList |> List.Extra.getAt (de.col - 2) |> Maybe.map String.fromChar |> Maybe.withDefault "")
-                    ++ "'"
-                    ++ (row |> String.toList |> List.Extra.getAt (de.col - 1) |> Maybe.map String.fromChar |> Maybe.withDefault "")
-                    ++ "'"
-                    ++ (row |> String.toList |> List.Extra.getAt de.col |> Maybe.map String.fromChar |> Maybe.withDefault "")
-                    ++ (row |> String.toList |> List.Extra.getAt (de.col + 1) |> Maybe.map String.fromChar |> Maybe.withDefault "")
-                    ++ (row |> String.toList |> List.Extra.getAt (de.col + 2) |> Maybe.map String.fromChar |> Maybe.withDefault "")
-                    ++ (row |> String.toList |> List.Extra.getAt (de.col + 3) |> Maybe.map String.fromChar |> Maybe.withDefault "")
-                    ++ (row |> String.toList |> List.Extra.getAt (de.col + 4) |> Maybe.map String.fromChar |> Maybe.withDefault "")
+                    ++ "\n"
+                    ++ spacesToProblem
+                    ++ "^"
             )
-        |> String.join "\n"
+        |> String.join ""
 
 
 
 {- Internal -}
+
+
+charIsWhitespace : Char -> Bool
+charIsWhitespace c =
+    c == ' ' || c == '\t' || c == '\n' || c == '\u{000D}'
 
 
 tagPair : Parser TagPair
@@ -247,8 +252,8 @@ tagPair =
         key : Parser String
         key =
             variable
-                { start = Char.isAlphaNum
-                , inner = \c -> Char.isAlphaNum c
+                { start = \c -> not <| charIsWhitespace c
+                , inner = \c -> not <| charIsWhitespace c
                 , reserved = Set.empty
                 }
     in
@@ -290,10 +295,48 @@ maybeCommentBlock =
 
 movetext : Parser String
 movetext =
+    let
+        legalFirstCharMoveText =
+            [ 'a'
+            , 'b'
+            , 'c'
+            , 'd'
+            , 'e'
+            , 'f'
+            , 'g'
+            , 'h'
+            , 'K'
+            , 'Q'
+            , 'B'
+            , 'N'
+            , 'K'
+            , 'n'
+            , 'R'
+            , 'O'
+            , 'o'
+            ]
+
+        allMoveText =
+            legalFirstCharMoveText
+                ++ [ '1'
+                   , '2'
+                   , '3'
+                   , '4'
+                   , '5'
+                   , '6'
+                   , '7'
+                   , '8'
+                   , '-'
+                   , '+'
+                   , '#'
+                   , '='
+                   , 'x'
+                   ]
+    in
     variable
-        { start = Char.isAlpha
-        , inner = \c -> Char.isAlphaNum c || c == '+' || c == '#' || c == '-'
-        , reserved = Set.fromList [ "1-0, 0-1", "1/2-1/2" ]
+        { start = \c -> List.member c legalFirstCharMoveText
+        , inner = \c -> List.member c allMoveText
+        , reserved = Set.fromList <| [ "1-0, 0-1", "1/2-1/2" ]
         }
 
 
@@ -380,7 +423,7 @@ problemToString : Problem -> String
 problemToString problem =
     case problem of
         Expecting s ->
-            "Expecting '" ++ s ++ "'"
+            "Expecting: " ++ s
 
         ExpectingInt ->
             "ExpectingInt"
@@ -404,10 +447,10 @@ problemToString problem =
             "ExpectingVariable"
 
         ExpectingSymbol s ->
-            "ExpectingSymbol '" ++ s ++ "'"
+            "ExpectingSymbol: " ++ s
 
         ExpectingKeyword s ->
-            "ExpectingKeyword '" ++ s ++ "'"
+            "ExpectingKeyword: " ++ s
 
         ExpectingEnd ->
             "ExpectingEnd"
@@ -416,7 +459,7 @@ problemToString problem =
             "UnexpectedChar"
 
         Problem s ->
-            "Problem '" ++ s ++ "'"
+            "Problem: " ++ s
 
         BadRepeat ->
             "BadRepeat"

--- a/src/Pgn.elm
+++ b/src/Pgn.elm
@@ -248,20 +248,11 @@ charIsWhitespace c =
 
 tagPair : Parser TagPair
 tagPair =
-    let
-        key : Parser String
-        key =
-            variable
-                { start = \c -> not <| charIsWhitespace c
-                , inner = \c -> not <| charIsWhitespace c
-                , reserved = Set.empty
-                }
-    in
     succeed TagPair
         |. spaces
         |. symbol "["
         |. spaces
-        |= key
+        |= (getChompedString <| chompWhile (\c -> not <| charIsWhitespace c))
         |. spaces
         |= (getChompedString <| multiComment "\"" "\"" Nestable)
         |. spaces

--- a/tests/ChessComPgnTests.elm
+++ b/tests/ChessComPgnTests.elm
@@ -49,4 +49,60 @@ sampleChessDotComPgnTagPairParsed =
 
 sampleChessDotComPgnMovesParsed : List Pgn.Move
 sampleChessDotComPgnMovesParsed =
-    [ { black = "d5", number = "1", white = "e4" }, { black = "e6", number = "2", white = "f3" }, { black = "Nc6", number = "3", white = "f4" }, { black = "a6", number = "4", white = "Bb5" }, { black = "bxc6", number = "5", white = "Bxc6+" }, { black = "Be7", number = "6", white = "d3" }, { black = "Nf6", number = "7", white = "Nf3" }, { black = "O-O", number = "8", white = "Nbd2" }, { black = "Ng4", number = "9", white = "c4" }, { black = "Bb4+", number = "10", white = "Nb3" }, { black = "Ne3", number = "11", white = "Bd2" }, { black = "Nc2+", number = "12", white = "Qe2" }, { black = "Nxa1", number = "13", white = "Kf1" }, { black = "Bc5", number = "14", white = "Nxa1" }, { black = "Ba7", number = "15", white = "Nb3" }, { black = "Re8", number = "16", white = "Bb4" }, { black = "Qf6", number = "17", white = "Na5" }, { black = "Qxf4", number = "18", white = "Nxc6" }, { black = "Qf6", number = "19", white = "Bd2" }, { black = "Qg6", number = "20", white = "Bg5" }, { black = "Rxe7", number = "21", white = "Ne7+" }, { black = "f6", number = "22", white = "Bxe7" }, { black = "Qg5", number = "23", white = "Nh4" }, { black = "Qc1+", number = "24", white = "Nf3" }, { black = "Bd4", number = "25", white = "Ne1" }, { black = "Bd7", number = "26", white = "Ba3" }, { black = "Bxb2", number = "27", white = "Bb4" }, { black = "Qf4+", number = "28", white = "Qc2" }, { black = "Bc1", number = "29", white = "Ke2" }, { black = "Be3", number = "30", white = "Kd1" }, { black = "dxe4", number = "31", white = "Nf3" }, { black = "e5", number = "32", white = "dxe4" }, { black = "Rd8", number = "33", white = "Bd2" }, { black = "Ba4+", number = "34", white = "Qd3" }, { black = "Bd1+", number = "35", white = "Ke2" }, { black = "Rxd3", number = "36", white = "Rxd1" }, { black = "Bxd2", number = "37", white = "Kxd3" }, { black = "Qxh2", number = "38", white = "Nxd2" }, { black = "Qxg2", number = "39", white = "c5" }, { black = "h5", number = "40", white = "Nc4" }, { black = "Qf1+", number = "41", white = "Rd2" }, { black = "Qe1", number = "42", white = "Kc3" }, { black = "h4", number = "43", white = "Kb4" }, { black = "Qxe4", number = "44", white = "Ka5" }, { black = "h3", number = "45", white = "Nb2" }, { black = "Qf4", number = "46", white = "Kxa6" }, { black = "Kf7", number = "47", white = "Rd8+" }, { black = "Kg6", number = "48", white = "Rd7+" }, { black = "h2", number = "49", white = "Kb7" }, { black = "Qf3+", number = "50", white = "Rd1" }, { black = "h1", number = "51", white = "Kxc7" } ]
+    [ { black = "d5", number = "1", white = "e4" }
+    , { black = "e6", number = "2", white = "f3" }
+    , { black = "Nc6", number = "3", white = "f4" }
+    , { black = "a6", number = "4", white = "Bb5" }
+    , { black = "bxc6", number = "5", white = "Bxc6+" }
+    , { black = "Be7", number = "6", white = "d3" }
+    , { black = "Nf6", number = "7", white = "Nf3" }
+    , { black = "O-O", number = "8", white = "Nbd2" }
+    , { black = "Ng4", number = "9", white = "c4" }
+    , { black = "Bb4+", number = "10", white = "Nb3" }
+    , { black = "Ne3", number = "11", white = "Bd2" }
+    , { black = "Nc2+", number = "12", white = "Qe2" }
+    , { black = "Nxa1", number = "13", white = "Kf1" }
+    , { black = "Bc5", number = "14", white = "Nxa1" }
+    , { black = "Ba7", number = "15", white = "Nb3" }
+    , { black = "Re8", number = "16", white = "Bb4" }
+    , { black = "Qf6", number = "17", white = "Na5" }
+    , { black = "Qxf4", number = "18", white = "Nxc6" }
+    , { black = "Qf6", number = "19", white = "Bd2" }
+    , { black = "Qg6", number = "20", white = "Bg5" }
+    , { black = "Rxe7", number = "21", white = "Ne7+" }
+    , { black = "f6", number = "22", white = "Bxe7" }
+    , { black = "Qg5", number = "23", white = "Nh4" }
+    , { black = "Qc1+", number = "24", white = "Nf3" }
+    , { black = "Bd4", number = "25", white = "Ne1" }
+    , { black = "Bd7", number = "26", white = "Ba3" }
+    , { black = "Bxb2", number = "27", white = "Bb4" }
+    , { black = "Qf4+", number = "28", white = "Qc2" }
+    , { black = "Bc1", number = "29", white = "Ke2" }
+    , { black = "Be3", number = "30", white = "Kd1" }
+    , { black = "dxe4", number = "31", white = "Nf3" }
+    , { black = "e5", number = "32", white = "dxe4" }
+    , { black = "Rd8", number = "33", white = "Bd2" }
+    , { black = "Ba4+", number = "34", white = "Qd3" }
+    , { black = "Bd1+", number = "35", white = "Ke2" }
+    , { black = "Rxd3", number = "36", white = "Rxd1" }
+    , { black = "Bxd2", number = "37", white = "Kxd3" }
+    , { black = "Qxh2", number = "38", white = "Nxd2" }
+    , { black = "Qxg2", number = "39", white = "c5" }
+    , { black = "h5", number = "40", white = "Nc4" }
+    , { black = "Qf1+", number = "41", white = "Rd2" }
+    , { black = "Qe1", number = "42", white = "Kc3" }
+    , { black = "h4", number = "43", white = "Kb4" }
+    , { black = "Qxe4", number = "44", white = "Ka5" }
+    , { black = "h3", number = "45", white = "Nb2" }
+    , { black = "Qf4", number = "46", white = "Kxa6" }
+    , { black = "Kf7", number = "47", white = "Rd8+" }
+    , { black = "Kg6", number = "48", white = "Rd7+" }
+    , { black = "h2", number = "49", white = "Kb7" }
+    , { black = "Qf3+", number = "50", white = "Rd1" }
+    , { black = "h1=Q", number = "51", white = "Kxc7" }
+    , { black = "Qxh1", number = "52", white = "Rxh1" }
+    , { black = "Qg2", number = "53", white = "c6" }
+    , { black = "Qxb2+", number = "54", white = "Kb7" }
+    , { black = "Qb8", number = "55", white = "Ka6" }
+    , { black = "e4", number = "56", white = "a4" }
+    ]

--- a/tests/DocExamplesTests.elm
+++ b/tests/DocExamplesTests.elm
@@ -83,10 +83,11 @@ testParseErrorToString =
             Pgn.parseTagPair tagPair
 
         expectedErrorString =
-            """error on row:  1, col: 8. Problem: Expecting '"'
+            """
 
-> '[Event After the title everything else in the tag pair needs to be in quotes!]'
-vent 'A'fter """
+error on row:  1, col: 8. Problem: Expecting: "
+> [Event After the title everything else in the tag pair needs to be in quotes!]
+   ^"""
     in
     test "Test that the example used in the parseErrorToString docs produces an expected result" <|
         \_ ->

--- a/tests/PgnFuzz.elm
+++ b/tests/PgnFuzz.elm
@@ -1,0 +1,69 @@
+module PgnFuzz exposing (fuzzTagPair)
+
+import Array
+import Expect
+import Fuzz exposing (Fuzzer, string)
+import Pgn
+import Random
+import Random.Char
+import Random.String
+import Shrink
+import String
+import Test exposing (Test, fuzz2)
+
+
+fuzzWordWithCharSet : Random.Generator Char -> Fuzzer String.String
+fuzzWordWithCharSet charSet =
+    Fuzz.custom
+        (Random.String.rangeLengthString 1 30 charSet)
+        Shrink.string
+
+
+wordFuzzer : Fuzzer String
+wordFuzzer =
+    Fuzz.oneOf
+        [ fuzzWordWithCharSet Random.Char.nko
+        , fuzzWordWithCharSet Random.Char.hangulJamo
+        , fuzzWordWithCharSet Random.Char.latin
+        , fuzzWordWithCharSet Random.Char.hiragana
+        , fuzzWordWithCharSet Random.Char.cyrillic
+        , fuzzWordWithCharSet Random.Char.cjkUnifiedIdeograph
+        , fuzzWordWithCharSet Random.Char.ethiopic
+        , fuzzWordWithCharSet Random.Char.latin
+        , fuzzWordWithCharSet Random.Char.latinExtendedA
+        , fuzzWordWithCharSet Random.Char.latinExtendedB
+        , fuzzWordWithCharSet Random.Char.latinExtendedC
+        , fuzzWordWithCharSet Random.Char.latinExtendedD
+        , fuzzWordWithCharSet Random.Char.generalPunctuation
+        ]
+
+
+fuzzTagPair : Test
+fuzzTagPair =
+    fuzz2 wordFuzzer (Fuzz.list wordFuzzer) "test any stings work as title/value tag pairs" <|
+        \title values ->
+            let
+                valueRaw =
+                    String.join " " values
+
+                valueInQuotes =
+                    "\"" ++ valueRaw ++ "\""
+
+                tagPair =
+                    "[ " ++ title ++ " " ++ valueInQuotes ++ " ]"
+
+                parsed =
+                    { title = title, value = valueRaw }
+            in
+            if String.trim title == "" || String.trim valueRaw == "" then
+                Expect.pass
+
+            else
+                case Pgn.parseTagPair tagPair of
+                    Ok res ->
+                        Expect.equal parsed res
+
+                    Err err ->
+                        err
+                            |> Pgn.parseErrorToString tagPair
+                            |> Expect.fail

--- a/tests/PgnTests.elm
+++ b/tests/PgnTests.elm
@@ -33,7 +33,7 @@ testParseTurnInlineComments =
             "11. {[some comments] [and more]} Bd2 {another set} 11... {even more} Ne3 {lastly, these}"
 
         res =
-            { number = "11", white = "Bd2", black = "Ne3" }
+            { black = "Ne3", number = "11", white = "Bd2" }
     in
     test "Test that a turn with inline comments parses correctly" <|
         \_ ->
@@ -54,17 +54,17 @@ testParseTurnsEolComments =
             "11. Bd2 11... Ne3; comment on turn 11\n12. Qe2 12... Nc2+; comment on turn 12\n13. Kf1 13... Nxa1; comment on turn 13\n"
 
         res =
-            [ { number = "11"
+            [ { black = "Ne3"
+              , number = "11"
               , white = "Bd2"
-              , black = "Ne3"
               }
-            , { number = "12"
+            , { black = "Nc2+"
+              , number = "12"
               , white = "Qe2"
-              , black = "Nc2+"
               }
-            , { number = "13"
+            , { black = "Nxa1"
+              , number = "13"
               , white = "Kf1"
-              , black = "Nxa1"
               }
             ]
     in

--- a/tests/PgnTests.elm
+++ b/tests/PgnTests.elm
@@ -1,4 +1,4 @@
-module PgnTests exposing (testParseTurnInlineComments, testParseTurnNoComments, testParseTurnsEolComments)
+module PgnTests exposing (testBangScenarioPropTestsRevealed, testParseTurnInlineComments, testParseTurnNoComments, testParseTurnsEolComments)
 
 import Expect
 import Pgn
@@ -77,4 +77,27 @@ testParseTurnsEolComments =
                 Err err ->
                     err
                         |> Pgn.parseErrorToString turns
+                        |> Expect.fail
+
+
+testBangScenarioPropTestsRevealed : Test
+testBangScenarioPropTestsRevealed =
+    let
+        tagpair =
+            "[! \"!\"]"
+
+        res =
+            { title = "!"
+            , value = "!"
+            }
+    in
+    test "Test an exclamation point in a tag pair parsed correcrtly" <|
+        \_ ->
+            case Pgn.parseTagPair tagpair of
+                Ok t ->
+                    Expect.equal t res
+
+                Err err ->
+                    err
+                        |> Pgn.parseErrorToString tagpair
                         |> Expect.fail


### PR DESCRIPTION
more permissive in tag pairs, less permissive in the movetext. beginning some fuzz tests to validate I'm making things better along the way.

I also made the parse error to string logic a little better in the process so this'll close #6 
