### PR TITLE
try to address the glibc error we're seeing when trying to run elm-format on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 language: elm
   
 script:


### PR DESCRIPTION
give ubuntu 18 a shot